### PR TITLE
Implement explicit config-driven training organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# novamod
+
+This repository contains model training and validation workflows for signal-based modification modeling.
+
+## Repository layout
+
+- `training/training-online.py`: config-driven online training entrypoint.
+- `training/configs/`: explicit JSON configs for experiments.
+- `training/validation-online_evalOnly.py`: evaluation and anomaly scoring workflow.
+- `training/dataset_utils.py`, `training/feature_utils.py`, `training/bam_utils.py`: core data and feature utilities.
+- `training/models/`: model definitions.
+- `training/state_dicts/`: saved checkpoints (large artifacts).
+- `training/*.ipynb`: exploratory and analysis notebooks.
+
+## Implemented organization changes
+
+This repo now uses **explicit experiment configs** for training:
+
+- Training parameters are no longer hard-coded inside `training-online.py`.
+- Use `training/configs/train_online.example.json` as a template for runs.
+- Slurm launcher `training/train.sh` accepts a config path argument and passes it through.
+
+Example:
+
+```bash
+cd training
+python training-online.py --config configs/train_online.example.json
+```
+
+## Next practical improvements
+
+1. Separate source code and generated artifacts into distinct folders.
+2. Standardize script naming (`train_online.py`, `validate_online.py`) while keeping backwards-compatible wrappers.
+3. Add CI checks for syntax and basic utility tests.

--- a/training/README.txt
+++ b/training/README.txt
@@ -1,19 +1,34 @@
-data: IVT
-feature: 11
-model: CNN-Transformer
+Training notes
+==============
 
+Dataset / feature setup
+-----------------------
+- data: IVT
+- feature count: 11
+- model family: CNN-Transformer
+
+Config-driven training (implemented)
+------------------------------------
+Training now reads all run settings from JSON config files.
+
+- example config: `configs/train_online.example.json`
+- launch locally: `python training-online.py --config configs/train_online.example.json`
+- slurm launch: `sbatch train.sh configs/train_online.example.json`
+
+Experiment naming reference
+---------------------------
 online-
-test0: DNA, trained on HG002-WGA (random subset), small model (64,64), static beta = 1e-3
-test1: RNA, trained on IVT, large model (256,128), static beta = 1e-4
-test2: RNA, trained on IVT, large model (256,128), warmup beta = 1e-3 in 10 epochs
-test3: DNA, trained on HG002-WGA, large model (256,128), warmup beta = 1e-3 in 10 epochs
-test4: DNA, trained on unmodified DNA oligos, large model (256,128), warmup beta = 1e-3 in 10 epochs
-test5: RNA, trained on unmodified RNA oligos, large model (256,128), warmup beta = 1e-3 in 10 epochs
-test6: DNA, trained on unmodified DNA oligos, large model (256,128), warmup beta = 1e-3 in 10 epochs, increased sampling rate
-test7: RNA, trained on unmodified RNA oligos, large model (256,128), warmup beta = 1e-3 in 10 epochs, increased sampling rate
-test8: DNA, trained on unmodified DNA oligos, large model (256,128), warmup beta = 1e-4 in 10 epochs, increased sampling rate
-test9: DNA, trained on unmodified DNA oligos (shuffled), large model (256,128), warmup beta = 1e-4 in 10 epochs
+- test0: DNA, HG002-WGA random subset, small model (64,64), static beta=1e-3
+- test1: RNA, IVT, large model (256,128), static beta=1e-4
+- test2: RNA, IVT, large model (256,128), warmup beta to 1e-3 over 10 epochs
+- test3: DNA, HG002-WGA, large model (256,128), warmup beta to 1e-3 over 10 epochs
+- test4: DNA, unmodified DNA oligos, large model (256,128), warmup beta to 1e-3 over 10 epochs
+- test5: RNA, unmodified RNA oligos, large model (256,128), warmup beta to 1e-3 over 10 epochs
+- test6: DNA, unmodified DNA oligos, large model (256,128), warmup beta to 1e-3 over 10 epochs, increased sampling rate
+- test7: RNA, unmodified RNA oligos, large model (256,128), warmup beta to 1e-3 over 10 epochs, increased sampling rate
+- test8: DNA, unmodified DNA oligos, large model (256,128), warmup beta to 1e-4 over 10 epochs, increased sampling rate
+- test9: DNA, shuffled unmodified DNA oligos, large model (256,128), warmup beta to 1e-4 over 10 epochs
 
 static-
-test0: DNA, oligos, static, small model (64,64), static beta = 1e-3
-test1: RNA, oligos, static, small model (64,64), static beta = 1e-3
+- test0: DNA oligos, static, small model (64,64), static beta=1e-3
+- test1: RNA oligos, static, small model (64,64), static beta=1e-3

--- a/training/configs/train_online.example.json
+++ b/training/configs/train_online.example.json
@@ -1,0 +1,46 @@
+{
+  "run": {
+    "run_name": "online_test9"
+  },
+  "data": {
+    "manifest_path": "data_manifest.csv",
+    "data_id": "dnaoligos-control1",
+    "max_samples_per_epoch": null,
+    "sampling": {
+      "kmer_len": 7,
+      "flank": 3,
+      "positions_per_read": 1000,
+      "max_kmer_count": 50000,
+      "normalize_signal": true,
+      "seed": 42
+    }
+  },
+  "loader": {
+    "batch_size": 256,
+    "num_workers": 20,
+    "persistent_workers": true
+  },
+  "model": {
+    "module": "models.model_v1_cnn_t",
+    "kwargs": {
+      "n_features": 11,
+      "seq_len": 7,
+      "d_model": 256,
+      "cnn_channels": 128,
+      "n_heads": 4,
+      "n_layers": 3,
+      "latent_dim": 16,
+      "dropout": 0.1,
+      "use_cls_token": true
+    }
+  },
+  "train": {
+    "lr": 0.0001,
+    "weight_decay": 0.0001,
+    "epochs": 20,
+    "beta_max": 0.0001,
+    "beta_warmup_epochs": 10,
+    "grad_clip": 1.0,
+    "recon": "mse"
+  }
+}

--- a/training/train.sh
+++ b/training/train.sh
@@ -7,13 +7,13 @@
 #SBATCH --gres=gpu:1
 #SBATCH -J Otrain --out=logs/%x.out
 
-TAG=$1
+CONFIG_PATH=${1:-configs/train_online.example.json}
 
-echo "Running training with tag: $TAG"
+echo "Running training with config: $CONFIG_PATH"
 
 module load CUDA
 
 echo "Running on node: $(hostname)"
 nvidia-smi
 
-python -u training-online.py
+python -u training-online.py --config "$CONFIG_PATH"

--- a/training/training-online.py
+++ b/training/training-online.py
@@ -1,195 +1,223 @@
 #!/usr/bin/env python
-# coding: utf-8
+"""Online training entrypoint for VAE models.
 
-# In[1]:
+This script is intentionally config-driven so experiments are explicit and reproducible.
+"""
 
+from __future__ import annotations
 
-from bam_utils import *
+import argparse
+import importlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
 
 import torch
-import torch.nn as nn
 from torch.nn import functional as F
-
-from dataclasses import dataclass
-from collections import defaultdict
-from typing import Dict
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-print(f"Using {device}.")
-
-
-# ### Loading Data
-
-# In[2]:
-
-from torch.utils.data import DataLoader
-import dataset_utils as du
-import pandas as pd
-
-import pandas as pd
-
-def load_manifest(path, data_id):
-    df = pd.read_csv(path).set_index("data_id")
-    row = df.loc[data_id]
-    if row.condition == "ref":
-        raise ValueError("Reference file provided.")
-    return row.file_path, df.loc[row.reference].file_path, row.type
-
-bam, ref, typ = load_manifest("data_manifest.csv", "dnaoligos-control1")
-
-#specify training data
-ds = du.SignalBAMkmerIterableDataset(
-    bam_path=bam,           # data
-    ref_fasta_path=ref, # reference
-    cfg=du.SamplingConfig(
-        kmer_len=7,
-        flank=3,
-        positions_per_read=1000,    # 10
-        max_kmer_count=50_000,
-        normalize_signal=True,
-        seed=42,
-    ),
-    seq_type=typ,                # type
-    max_samples_per_epoch=None,
-)
-
-loader = DataLoader(
-    ds,
-    batch_size=256,
-    num_workers=20,
-    persistent_workers=True,
-)
-
-
-# ### Training
-
-# In[3]:
-
-
-# Loss function
-def vae_loss(x: torch.Tensor, x_hat: torch.Tensor, mu: torch.Tensor, logvar: torch.Tensor,
-             beta: float = 1.0, recon: str = "mse") -> Dict[str, torch.Tensor]:
-    if recon == "mse":
-        recon_loss = F.mse_loss(x_hat, x, reduction="mean")
-    elif recon == "l1":
-        recon_loss = F.l1_loss(x_hat, x, reduction="mean")
-
-    # KL divergence for diagonal Gaussian q(z|x) vs N(0,1)
-    kl = 0.5 * torch.mean(torch.sum(torch.exp(logvar) + mu**2 - 1.0 - logvar, dim=1))
-    loss = recon_loss + beta * kl
-    return {"loss": loss, "recon": recon_loss, "kl": kl}
-
-
-# In[4]:
-
-
 from torch.optim import AdamW
+from torch.utils.data import DataLoader
+
+import dataset_utils as du
+
 
 @dataclass
 class TrainConfig:
     lr: float = 2e-4
     weight_decay: float = 1e-4
     epochs: int = 50
-    beta_max: float = 1.0        # final beta for KL
-    beta_warmup_epochs: int = 10 # linear warmup for KL
+    beta_max: float = 1.0
+    beta_warmup_epochs: int = 10
     grad_clip: float = 1.0
     recon: str = "mse"
 
 
-def train_vae(model, dataset, loader, device, model_name, run_name, cfg: TrainConfig):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train VAE model on online iterable dataset")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/train_online.example.json"),
+        help="Path to training config JSON",
+    )
+    return parser.parse_args()
+
+
+def load_manifest(path: str, data_id: str) -> tuple[str, str, str]:
+    import pandas as pd
+
+    df = pd.read_csv(path).set_index("data_id")
+    row = df.loc[data_id]
+    if row.condition == "ref":
+        raise ValueError("Reference file provided as training input.")
+    return row.file_path, df.loc[row.reference].file_path, row.type
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_loader(cfg: Dict[str, Any]) -> tuple[Any, DataLoader]:
+    manifest_path = cfg["data"]["manifest_path"]
+    data_id = cfg["data"]["data_id"]
+    bam, ref, seq_type = load_manifest(manifest_path, data_id)
+
+    sampling_cfg = du.SamplingConfig(**cfg["data"]["sampling"])
+    dataset = du.SignalBAMkmerIterableDataset(
+        bam_path=bam,
+        ref_fasta_path=ref,
+        cfg=sampling_cfg,
+        seq_type=seq_type,
+        max_samples_per_epoch=cfg["data"].get("max_samples_per_epoch"),
+    )
+
+    loader = DataLoader(
+        dataset,
+        batch_size=cfg["loader"].get("batch_size", 256),
+        num_workers=cfg["loader"].get("num_workers", 20),
+        persistent_workers=cfg["loader"].get("persistent_workers", True),
+    )
+    return dataset, loader
+
+
+def build_model(cfg: Dict[str, Any]) -> tuple[str, torch.nn.Module]:
+    module = importlib.import_module(cfg["model"]["module"])
+    importlib.reload(module)
+    model = module.VAE(**cfg["model"]["kwargs"])
+    return module.META.name, model
+
+
+def vae_loss(
+    x: torch.Tensor,
+    x_hat: torch.Tensor,
+    mu: torch.Tensor,
+    logvar: torch.Tensor,
+    beta: float = 1.0,
+    recon: str = "mse",
+) -> Dict[str, torch.Tensor]:
+    if recon == "mse":
+        recon_loss = F.mse_loss(x_hat, x, reduction="mean")
+    elif recon == "l1":
+        recon_loss = F.l1_loss(x_hat, x, reduction="mean")
+    else:
+        raise ValueError(f"Unsupported recon loss: {recon}")
+
+    kl = 0.5 * torch.mean(torch.sum(torch.exp(logvar) + mu**2 - 1.0 - logvar, dim=1))
+    loss = recon_loss + beta * kl
+    return {"loss": loss, "recon": recon_loss, "kl": kl}
+
+
+def train_vae(
+    model: torch.nn.Module,
+    dataset: Any,
+    loader: DataLoader,
+    device: torch.device,
+    model_name: str,
+    run_name: str,
+    cfg: TrainConfig,
+) -> torch.nn.Module:
     model.to(device)
     parameters = [
-        {"params": [p for n, p in model.named_parameters() if not any(nd in n for nd in ["bias", "LayerNorm.weight"])], "weight_decay": cfg.weight_decay},
-        {"params": [p for n, p in model.named_parameters() if any(nd in n for nd in ["bias", "LayerNorm.weight"])], "weight_decay": 0.0}
+        {
+            "params": [
+                p
+                for n, p in model.named_parameters()
+                if not any(nd in n for nd in ["bias", "LayerNorm.weight"])
+            ],
+            "weight_decay": cfg.weight_decay,
+        },
+        {
+            "params": [
+                p
+                for n, p in model.named_parameters()
+                if any(nd in n for nd in ["bias", "LayerNorm.weight"])
+            ],
+            "weight_decay": 0.0,
+        },
     ]
-    opt = AdamW(parameters, lr=cfg.lr)
+    optimizer = AdamW(parameters, lr=cfg.lr)
 
     for epoch in range(1, cfg.epochs + 1):
-        dataset.set_epoch(epoch)   # change rng seed for data sampling
-        beta = cfg.beta_max * min(1.0, epoch / cfg.beta_warmup_epochs) if cfg.beta_warmup_epochs > 0 else cfg.beta_max
+        dataset.set_epoch(epoch)
+        beta = (
+            cfg.beta_max * min(1.0, epoch / cfg.beta_warmup_epochs)
+            if cfg.beta_warmup_epochs > 0
+            else cfg.beta_max
+        )
 
-        #train
         model.train()
-        tr_total = tr_vae = tr_recon = tr_kl = tr_msm = 0.0
+        tr_total = tr_recon = tr_kl = 0.0
         n_batches = 0
 
         for x, _, _ in loader:
             x = x.to(device)
-            opt.zero_grad(set_to_none=True)
+            optimizer.zero_grad(set_to_none=True)
 
             out = model(x)
-            vae_losses = vae_loss(x, out["x_hat"], out["mu"], out["logvar"], beta=beta, recon=cfg.recon)
+            losses = vae_loss(x, out["x_hat"], out["mu"], out["logvar"], beta=beta, recon=cfg.recon)
+            losses["loss"].backward()
 
-            total_loss = vae_losses["loss"]
-            total_loss.backward()
-
-            if cfg.grad_clip is not None and cfg.grad_clip > 0:
+            if cfg.grad_clip and cfg.grad_clip > 0:
                 torch.nn.utils.clip_grad_norm_(model.parameters(), cfg.grad_clip)
 
-            opt.step()
+            optimizer.step()
 
-            tr_total += float(total_loss.detach().cpu())
-            tr_vae   += float(vae_losses["loss"].detach().cpu())
-            tr_recon += float(vae_losses["recon"].detach().cpu())
-            tr_kl    += float(vae_losses["kl"].detach().cpu())
+            tr_total += float(losses["loss"].detach().cpu())
+            tr_recon += float(losses["recon"].detach().cpu())
+            tr_kl += float(losses["kl"].detach().cpu())
             n_batches += 1
 
         tr_total /= max(1, n_batches)
-        tr_vae   /= max(1, n_batches)
         tr_recon /= max(1, n_batches)
-        tr_kl    /= max(1, n_batches)
+        tr_kl /= max(1, n_batches)
 
         print(
             f"Epoch {epoch:03d} | beta={beta:.4f} | "
-            f"train total {tr_total:.5f} (vae {tr_vae:.5f}, recon {tr_recon:.5f}, kl {tr_kl:.5f})"
+            f"train total {tr_total:.5f} (recon {tr_recon:.5f}, kl {tr_kl:.5f})"
         )
 
-        #for early stop
-        store_path = f"state_dicts/{model_name}/{run_name}-epoch{epoch}.pt"
-        torch.save({
-            'model_state_dict': model.state_dict(), 
-            'beta': beta, 
-            'epoch': epoch,
-            'model': model_name,
-            'run': run_name
-        }, store_path)
+        store_path = Path("state_dicts") / model_name / f"{run_name}-epoch{epoch}.pt"
+        store_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "model_state_dict": model.state_dict(),
+                "beta": beta,
+                "epoch": epoch,
+                "model": model_name,
+                "run": run_name,
+            },
+            store_path,
+        )
 
     return model
 
 
-# In[ ]:
+def main() -> None:
+    args = parse_args()
+    cfg = load_json(args.config)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using {device}.")
+
+    dataset, loader = build_loader(cfg)
+    model_name, model = build_model(cfg)
+
+    train_cfg = TrainConfig(**cfg["train"])
+    run_name = cfg["run"]["run_name"]
+
+    print(f"Training {model_name} with run '{run_name}' ...")
+    train_vae(
+        model=model,
+        dataset=dataset,
+        loader=loader,
+        device=device,
+        model_name=model_name,
+        run_name=run_name,
+        cfg=train_cfg,
+    )
 
 
-# Import model
-import importlib
-import models.model_v1_cnn_t as m  # change model here
-importlib.reload(m)
-model_name = m.META.name
-
-model = m.VAE(
-    n_features=11,
-    seq_len=7,
-    d_model=256,
-    cnn_channels=128,
-    n_heads=4,
-    n_layers=3,
-    latent_dim=16,
-    dropout=0.1,
-    use_cls_token=True,
-)
-#print(model)
-
-# Change run configurations here
-run_name = "online_test9"
-n_epoch = 20
-
-cfg = TrainConfig(epochs=n_epoch, beta_max=1e-4, weight_decay=1e-4, beta_warmup_epochs=10, lr=1e-4, recon="mse")
-print(f"Training {model_name} with {n_epoch} epochs ...")
-model = train_vae(model, dataset=ds, loader=loader, device=device, model_name=model_name, run_name=run_name, cfg=cfg)
-
-
-# In[ ]:
-
-
-
-
+if __name__ == "__main__":
+    main()

--- a/training/validation-online_evalOnly.py
+++ b/training/validation-online_evalOnly.py
@@ -51,7 +51,7 @@ def valData(bam, ref, seq_type, method, spec, num_workers=20):
     if method == "site":
         #spec: pos_list
         ds = du.SignalBAMRefPosValidationDataset(
-            bam_path=c_bam,
+            bam_path=bam,
             ref_fasta_path=ref,
             seq_type=seq_type,
             pos_list=spec,


### PR DESCRIPTION
### Motivation
- Make experiment runs explicit and reproducible by moving hard-coded training parameters into per-run config files and a clean launcher.  
- Improve automation and reproducibility by parameterizing the Slurm launcher so CI / schedulers can declare the experiment surface.  
- Surface the repository organization and next steps in documentation to encourage a consistent experiment lifecycle.

### Description
- Refactor `training/training-online.py` into a config-driven launcher that reads a JSON config, constructs dataset/loader/model from config sections, and performs training using those values (replaces previous hard-coded run values).  
- Add `training/configs/train_online.example.json` as a concrete template with `run`, `data`, `loader`, `model`, and `train` blocks, and update `training/train.sh` to accept a config path and pass `--config` to the launcher.  
- Update docs (`README.md` and `training/README.txt`) to describe the new layout and usage, and apply small robustness fixes: lazy-import `pandas` in `load_manifest`, create checkpoint directories before `torch.save`, tidy optimizer/param-group setup, and fix validation script to use the function `bam` argument for site-mode loading.

### Testing
- Ran Python syntax check with `python -m py_compile training/*.py training/models/*.py`, which completed successfully.  
- Validated the example config with `python -m json.tool training/configs/train_online.example.json`, which succeeded.  
- Attempted to run `cd training && python training-online.py --help`, but runtime execution failed in the current environment due to missing runtime dependencies (`torch`), so CLI behavior was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0345ed608324941f5f405458b087)