### PR TITLE
Add configurable VAE reconstruction losses and Gaussian k-mer weighting

### DIFF
--- a/training/configs/train_online.example.json
+++ b/training/configs/train_online.example.json
@@ -41,6 +41,10 @@
     "beta_max": 0.0001,
     "beta_warmup_epochs": 10,
     "grad_clip": 1.0,
-    "recon": "mse"
+    "recon": "mse",
+    "huber_delta": 1.0,
+    "nll_var": 1.0,
+    "kmer_weight_center_base": 0.0,
+    "kmer_weight_sd": 1.5
   }
 }

--- a/training/training-online.py
+++ b/training/training-online.py
@@ -31,6 +31,10 @@ class TrainConfig:
     beta_warmup_epochs: int = 10
     grad_clip: float = 1.0
     recon: str = "mse"
+    huber_delta: float = 1.0
+    nll_var: float = 1.0
+    kmer_weight_center_base: float = 0.0
+    kmer_weight_sd: float = 1.0
 
 
 def parse_args() -> argparse.Namespace:
@@ -96,13 +100,36 @@ def vae_loss(
     logvar: torch.Tensor,
     beta: float = 1.0,
     recon: str = "mse",
+    huber_delta: float = 1.0,
+    nll_var: float = 1.0,
+    kmer_weight_center_base: float = 0.0,
+    kmer_weight_sd: float = 1.0,
 ) -> Dict[str, torch.Tensor]:
+    if x.dim() != 3:
+        raise ValueError(f"Expected reconstruction tensors shaped [B, T, F], got {x.shape}.")
+
+    seq_len = x.shape[1]
+    kmer_pos = torch.arange(seq_len, device=x.device, dtype=x.dtype) - (seq_len - 1) / 2.0
+    if kmer_weight_sd <= 0:
+        raise ValueError("kmer_weight_sd must be > 0.")
+    kmer_weights = torch.exp(-0.5 * ((kmer_pos - kmer_weight_center_base) / kmer_weight_sd) ** 2)
+    kmer_weights = kmer_weights / kmer_weights.sum()
+
     if recon == "mse":
-        recon_loss = F.mse_loss(x_hat, x, reduction="mean")
+        pointwise_recon = F.mse_loss(x_hat, x, reduction="none")
     elif recon == "l1":
-        recon_loss = F.l1_loss(x_hat, x, reduction="mean")
+        pointwise_recon = F.l1_loss(x_hat, x, reduction="none")
+    elif recon == "huber":
+        pointwise_recon = F.huber_loss(x_hat, x, reduction="none", delta=huber_delta)
+    elif recon == "nll":
+        if nll_var <= 0:
+            raise ValueError("nll_var must be > 0.")
+        pointwise_recon = -torch.distributions.Normal(x_hat, nll_var**0.5).log_prob(x)
     else:
         raise ValueError(f"Unsupported recon loss: {recon}")
+
+    recon_per_timestep = pointwise_recon.mean(dim=2)
+    recon_loss = torch.sum(recon_per_timestep * kmer_weights.unsqueeze(0), dim=1).mean()
 
     kl = 0.5 * torch.mean(torch.sum(torch.exp(logvar) + mu**2 - 1.0 - logvar, dim=1))
     loss = recon_loss + beta * kl
@@ -156,7 +183,18 @@ def train_vae(
             optimizer.zero_grad(set_to_none=True)
 
             out = model(x)
-            losses = vae_loss(x, out["x_hat"], out["mu"], out["logvar"], beta=beta, recon=cfg.recon)
+            losses = vae_loss(
+                x,
+                out["x_hat"],
+                out["mu"],
+                out["logvar"],
+                beta=beta,
+                recon=cfg.recon,
+                huber_delta=cfg.huber_delta,
+                nll_var=cfg.nll_var,
+                kmer_weight_center_base=cfg.kmer_weight_center_base,
+                kmer_weight_sd=cfg.kmer_weight_sd,
+            )
             losses["loss"].backward()
 
             if cfg.grad_clip and cfg.grad_clip > 0:


### PR DESCRIPTION
### Motivation
- Allow training to use reconstruction losses other than plain MSE (e.g. Huber and NLL) to better match desired robustness and likelihood-based objectives.
- Enable penalizing reconstruction errors near the central base of k-mers more strongly than distal positions via a configurable Gaussian timestep weighting so experiments can emphasize center bases.

### Description
- Added new training config knobs `huber_delta`, `nll_var`, `kmer_weight_center_base`, and `kmer_weight_sd` to `TrainConfig` and the example config so loss behavior is fully configurable via `train` JSON fields.
- Extended `vae_loss` to support `huber` and `nll` reconstruction modes and to compute a normalized Gaussian positional weighting over k-mer timesteps (centered around the k-mer midpoint and shiftable by `kmer_weight_center_base`) which is applied to per-timestep reconstruction error before reduction.
- Added input validation for `kmer_weight_sd` and `nll_var`, and preserved KL computation; the training loop is wired to pass the new config fields into `vae_loss`.
- Updated `training/configs/train_online.example.json` to expose the new options and default values.

### Testing
- Ran `python -m py_compile training/training-online.py` to validate the module syntax, which succeeded.
- Attempted a smoke test that calls `vae_loss` with each recon mode, but the runtime smoke test could not run because the environment is missing `torch` (raised `ModuleNotFoundError`), so no runtime assertions were executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e3da2aee88324a73d44885f259eea)